### PR TITLE
Fix enemy movement based on FPS; Updated enemy/ally speeds; scale canvas w/ resolution

### DIFF
--- a/Assets/Resources/Prefabs/Allies/Ally.prefab
+++ b/Assets/Resources/Prefabs/Allies/Ally.prefab
@@ -224,7 +224,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   health: 0
-  speed: 0.003
+  speed: 1.5
   scoreValue: 10
   maxTime: 2
   rescueSpeed: 5

--- a/Assets/Resources/Prefabs/Enemies/AimDownEnemy.prefab
+++ b/Assets/Resources/Prefabs/Enemies/AimDownEnemy.prefab
@@ -132,7 +132,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   health: 2
-  speed: 0.01
+  speed: 5
   scoreValue: 5
   projectileModule: {fileID: -1123020311221043006}
   timeTilDamage: 0.5

--- a/Assets/Resources/Prefabs/Enemies/AimLeftEnemy.prefab
+++ b/Assets/Resources/Prefabs/Enemies/AimLeftEnemy.prefab
@@ -101,7 +101,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   health: 1
-  speed: 0.003
+  speed: 1
   scoreValue: 5
   projectileModule: {fileID: 6911115032455514576}
   timeTilDamage: 0.25

--- a/Assets/Resources/Prefabs/Enemies/AimRightEnemy.prefab
+++ b/Assets/Resources/Prefabs/Enemies/AimRightEnemy.prefab
@@ -101,7 +101,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   health: 1
-  speed: 0.003
+  speed: 1
   scoreValue: 5
   projectileModule: {fileID: 2658522959401910350}
   timeTilDamage: 0.25

--- a/Assets/Resources/Prefabs/Enemies/BurstDownEnemy.prefab
+++ b/Assets/Resources/Prefabs/Enemies/BurstDownEnemy.prefab
@@ -132,7 +132,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   health: 2
-  speed: 0.01
+  speed: 5
   scoreValue: 5
   projectileModule: {fileID: 8332667076958421905}
   timeTilDamage: 1

--- a/Assets/Resources/Prefabs/Enemies/SpreadDownEnemy.prefab
+++ b/Assets/Resources/Prefabs/Enemies/SpreadDownEnemy.prefab
@@ -132,7 +132,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   health: 1
-  speed: 0.001
+  speed: 0.9
   scoreValue: 5
   projectileModule: {fileID: 5763963021006144630}
   timeTilDamage: 1

--- a/Assets/Resources/Prefabs/Enemies/StraightDownEnemy.prefab
+++ b/Assets/Resources/Prefabs/Enemies/StraightDownEnemy.prefab
@@ -132,7 +132,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   health: 1
-  speed: 0.002
+  speed: 2
   scoreValue: 5
   projectileModule: {fileID: 4132119150226136713}
   timeTilDamage: 1

--- a/Assets/Scenes/LevelOne.unity
+++ b/Assets/Scenes/LevelOne.unity
@@ -21217,10 +21217,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
+  m_UiScaleMode: 1
   m_ReferencePixelsPerUnit: 100
   m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
+  m_ReferenceResolution: {x: 1920, y: 1080}
   m_ScreenMatchMode: 0
   m_MatchWidthOrHeight: 0
   m_PhysicalUnit: 3

--- a/Assets/Scripts/Entities/Ally.cs
+++ b/Assets/Scripts/Entities/Ally.cs
@@ -71,7 +71,7 @@ public class Ally : Entity
         }
         else if (ShouldMove())
         {
-            this.transform.position += direction * speed;
+            this.transform.position += direction * speed * Time.deltaTime;
         }
     }
 

--- a/Assets/Scripts/Entities/Enemies/MovingEnemy.cs
+++ b/Assets/Scripts/Entities/Enemies/MovingEnemy.cs
@@ -72,7 +72,7 @@ public class MovingEnemy : Enemy
         base.Move();
         if (ShouldMove())
         {
-            this.transform.position += direction * speed;
+            this.transform.position += direction * speed * Time.deltaTime;
         }
     }
 


### PR DESCRIPTION
* Updated entity movements to be based on FPS. Before, entities would move without any regards to the FPS of the game, which was impacted by the current native resolution. Due to this there were issues where entities moved much more slowly with higher  resolutions. 
* [Reference 1](https://answers.unity.com/questions/490687/when-to-use-timedeltatime.html) [Reference 2](https://forum.unity.com/threads/speed-changes-of-transform-positionwith-screen-resolution.1126385/)
* Entity speeds are updated to compensate for new position updates
* Also updated the canvas settings to scale w/ resolution.