### PR TITLE
Fix beam bugs

### DIFF
--- a/Assets/Resources/Prefabs/Allies/Ally.prefab
+++ b/Assets/Resources/Prefabs/Allies/Ally.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 948906679947641620}
   - component: {fileID: 948906679947641623}
   - component: {fileID: 948906679947641622}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: Sphere
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -110,7 +110,7 @@ GameObject:
   - component: {fileID: 948906680092964809}
   - component: {fileID: 948906680092964852}
   - component: {fileID: 948906680092964853}
-  m_Layer: 0
+  m_Layer: 7
   m_Name: Ally
   m_TagString: Ally
   m_Icon: {fileID: 0}

--- a/Assets/Resources/Prefabs/Enemies/AimDownEnemy.prefab
+++ b/Assets/Resources/Prefabs/Enemies/AimDownEnemy.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 22429610}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: FirePoint
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -44,7 +44,7 @@ GameObject:
   - component: {fileID: 502711955769907588}
   - component: {fileID: -1123020311221043006}
   - component: {fileID: -5276820041182803937}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: AimDownEnemy
   m_TagString: Enemy
   m_Icon: {fileID: 0}

--- a/Assets/Resources/Prefabs/Enemies/AimLeftEnemy.prefab
+++ b/Assets/Resources/Prefabs/Enemies/AimLeftEnemy.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 502711955769907588}
   - component: {fileID: 6911115032455514576}
   - component: {fileID: 3404267714523473115}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: AimLeftEnemy
   m_TagString: Enemy
   m_Icon: {fileID: 0}
@@ -163,7 +163,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4797570731799910607}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: FirePoint
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Resources/Prefabs/Enemies/AimRightEnemy.prefab
+++ b/Assets/Resources/Prefabs/Enemies/AimRightEnemy.prefab
@@ -13,7 +13,7 @@ GameObject:
   - component: {fileID: 502711955769907588}
   - component: {fileID: 2658522959401910350}
   - component: {fileID: 7451077338285849871}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: AimRightEnemy
   m_TagString: Enemy
   m_Icon: {fileID: 0}
@@ -163,7 +163,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7685822482654319963}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: FirePoint
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Resources/Prefabs/Enemies/BurstDownEnemy.prefab
+++ b/Assets/Resources/Prefabs/Enemies/BurstDownEnemy.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 22429610}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: FirePoint
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -44,7 +44,7 @@ GameObject:
   - component: {fileID: 502711955769907588}
   - component: {fileID: 8332667076958421905}
   - component: {fileID: -5276820041182803937}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: BurstDownEnemy
   m_TagString: Enemy
   m_Icon: {fileID: 0}

--- a/Assets/Resources/Prefabs/Enemies/CurveLeftEnemy.prefab
+++ b/Assets/Resources/Prefabs/Enemies/CurveLeftEnemy.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1332938077877585678}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: FirePoint
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -44,7 +44,7 @@ GameObject:
   - component: {fileID: 8232285199866932515}
   - component: {fileID: 3695355335642394797}
   - component: {fileID: 515016298930781713}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: CurveLeftEnemy
   m_TagString: Enemy
   m_Icon: {fileID: 0}

--- a/Assets/Resources/Prefabs/Enemies/CurveRightEnemy.prefab
+++ b/Assets/Resources/Prefabs/Enemies/CurveRightEnemy.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 7588326598706264227}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: FirePoint
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -44,7 +44,7 @@ GameObject:
   - component: {fileID: 8232285199866932515}
   - component: {fileID: 7372073500056015142}
   - component: {fileID: 4561789017648308447}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: CurveRightEnemy
   m_TagString: Enemy
   m_Icon: {fileID: 0}

--- a/Assets/Resources/Prefabs/Enemies/SpreadDownEnemy.prefab
+++ b/Assets/Resources/Prefabs/Enemies/SpreadDownEnemy.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 22429610}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: FirePoint
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -44,7 +44,7 @@ GameObject:
   - component: {fileID: 502711955769907588}
   - component: {fileID: 5763963021006144630}
   - component: {fileID: -5276820041182803937}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: SpreadDownEnemy
   m_TagString: Enemy
   m_Icon: {fileID: 0}

--- a/Assets/Resources/Prefabs/Enemies/StraightDownEnemy.prefab
+++ b/Assets/Resources/Prefabs/Enemies/StraightDownEnemy.prefab
@@ -9,7 +9,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 22429610}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: FirePoint
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -44,7 +44,7 @@ GameObject:
   - component: {fileID: 502711955769907588}
   - component: {fileID: 4132119150226136713}
   - component: {fileID: -5276820041182803937}
-  m_Layer: 0
+  m_Layer: 6
   m_Name: StraightDownEnemy
   m_TagString: Enemy
   m_Icon: {fileID: 0}

--- a/Assets/Scripts/Beams/DarkBeam.cs
+++ b/Assets/Scripts/Beams/DarkBeam.cs
@@ -18,9 +18,6 @@ public class DarkBeam : Laser
         FillLists();
         DisableLaser();
     }
-    public override void Shoot()
-    {
-    }
     public void UpdateLaser(Vector2 mousePosition)
     {
 
@@ -38,7 +35,6 @@ public class DarkBeam : Laser
 
         if (hit && hit.transform.gameObject.tag == "Enemy")
         {
-            // Debug.Log("WEE");
             lineRenderer.SetPosition(1, hit.point);
             Enemy enemy = hit.transform.gameObject.GetComponent<Enemy>();
             enemy.TakeDamage(damage);

--- a/Assets/Scripts/Beams/DarkBeam.cs
+++ b/Assets/Scripts/Beams/DarkBeam.cs
@@ -30,9 +30,7 @@ public class DarkBeam : Laser
         lineRenderer.SetPosition(1, newVec);
 
         Vector2 direction = (Vector2)newVec - (Vector2)transform.position;
-        RaycastHit2D hit = Physics2D.Raycast((Vector2)transform.position, direction.normalized, direction.magnitude);
-
-
+        RaycastHit2D hit = Physics2D.Raycast((Vector2)transform.position, direction.normalized, direction.magnitude, LayerMask.GetMask("Enemy"));
         if (hit && hit.transform.gameObject.tag == "Enemy")
         {
             lineRenderer.SetPosition(1, hit.point);

--- a/Assets/Scripts/Beams/Laser.cs
+++ b/Assets/Scripts/Beams/Laser.cs
@@ -14,7 +14,6 @@ public abstract class Laser : MonoBehaviour
         DisableLaser();
 
     }
-    public abstract void Shoot();
     public void EnableLaser()
     {
         lineRenderer.enabled = true;

--- a/Assets/Scripts/Beams/LightBeam.cs
+++ b/Assets/Scripts/Beams/LightBeam.cs
@@ -33,7 +33,7 @@ public class LightBeam : Laser
         lineRenderer.SetPosition(1, new Vector2(firePoint.position.x, 16));
 
         Vector2 direction = (Vector2)lineRenderer.GetPosition(1) - (Vector2)transform.position;
-        RaycastHit2D hit = Physics2D.Raycast((Vector2)transform.position, direction.normalized, direction.magnitude);
+        RaycastHit2D hit = Physics2D.Raycast((Vector2)transform.position, direction.normalized, direction.magnitude, LayerMask.GetMask("Ally"));
         if (hit && hit.transform.gameObject.tag == "Ally")
         {
             Ally ally = hit.transform.gameObject.GetComponent<Ally>();

--- a/Assets/Scripts/Beams/LightBeam.cs
+++ b/Assets/Scripts/Beams/LightBeam.cs
@@ -38,24 +38,7 @@ public class LightBeam : Laser
         {
             Ally ally = hit.transform.gameObject.GetComponent<Ally>();
             lineRenderer.SetPosition(1, new Vector2(firePoint.position.x, hit.point.y));
-            if (ally.Rescue())
-            {
-                DisableLaser();
-            }
-
+            ally.Rescue();
         }
-        else
-        {
-            StartCoroutine(ShootEffect());
-        }
-    }
-    public override void Shoot()
-    {
-        EnableLaser();
-    }
-    protected IEnumerator ShootEffect()
-    {
-        yield return new WaitForSeconds(laserDuration);
-        DisableLaser();
     }
 }

--- a/Assets/Scripts/Player/PlayerController.cs
+++ b/Assets/Scripts/Player/PlayerController.cs
@@ -32,7 +32,8 @@ public class PlayerController : Singleton<PlayerController>
     private void OnDisable()
     {
         playerControls.Disable();
-        playerControls.Space.LightBeam.performed -= LightBeam;
+        playerControls.Space.LightBeam.performed -= EnableLightBeam;
+        playerControls.Space.LightBeam.canceled -= DisableLightBeam;
         playerControls.Space.Shoot.performed -= EnableDarkBeam;
         playerControls.Space.Shoot.canceled -= DisableDarkBeam;
     }
@@ -40,16 +41,19 @@ public class PlayerController : Singleton<PlayerController>
     void Start()
     {
         UIManager.Instance.UpdateHealth(health);
-        playerControls.Space.LightBeam.performed += LightBeam;
+        playerControls.Space.LightBeam.performed += EnableLightBeam;
+        playerControls.Space.LightBeam.canceled += DisableLightBeam;
         playerControls.Space.Shoot.performed += EnableDarkBeam;
         playerControls.Space.Shoot.canceled += DisableDarkBeam;
     }
-
-    private void LightBeam(InputAction.CallbackContext context)
+    private void EnableLightBeam(InputAction.CallbackContext context)
     {
-        lightBeam.Shoot();
+        lightBeam.EnableLaser();
     }
-
+    private void DisableLightBeam(InputAction.CallbackContext context)
+    {
+        lightBeam.DisableLaser();
+    }
     private void DisableDarkBeam(InputAction.CallbackContext context)
     {
         for (int i = 0; i < darkBeam.Count; i++)


### PR DESCRIPTION
sometimes a projectile would block the enemy, so the raycast was hitting the projectile. Since the raycast only checks on the first hit, and the first hit was the projectile, the dark beam would go through it and it would look like it didnt hit the enemy. Updated the prefabs for enemy and layer to be on their own layer, and updated the Raycast to only check colliders on the specific layers.