### PR TITLE
Fix entity health bug

### DIFF
--- a/Assets/Scripts/Entities/Ally.cs
+++ b/Assets/Scripts/Entities/Ally.cs
@@ -65,7 +65,7 @@ public class Ally : Entity
 
 
     // Update is called once per frame
-    protected override void Update()
+    void Update()
     {
         if (rescued)
         {

--- a/Assets/Scripts/Entities/Enemy.cs
+++ b/Assets/Scripts/Entities/Enemy.cs
@@ -44,9 +44,8 @@ public class Enemy : Entity
 
 
     // Update is called once per frame
-    protected override void Update()
+    void Update()
     {
-        base.Update();
         // Only attempt to attack if infinite attacks
         // or there are enough current attacks
         if (maximumAttacks <= 0 || currentAttacks > 0)
@@ -76,9 +75,9 @@ public class Enemy : Entity
         currentDamageTime -= Time.deltaTime;
         if (currentDamageTime <= 0)
         {
-            health -= damagedTaken;
+            currentHealth -= damagedTaken;
             sr.material = ResourceManager.Instance.MaterialDictionary["WhiteFlash"];
-            if (health <= 0)
+            if (currentHealth <= 0)
             {
                 DestroyEnemy();
             }

--- a/Assets/Scripts/Entities/Entity.cs
+++ b/Assets/Scripts/Entities/Entity.cs
@@ -15,30 +15,15 @@ public class Entity : MonoBehaviour
 
     protected int currentHealth;
 
-    // private bool hasBeenInvisible;
-
     public virtual void OnSpawn() { return; }
     public virtual void Attack() { return; }
     public virtual void Move() { return; }
     public virtual void OnDeath() { return; }
-
     public virtual void OnReset() { return; }
 
-    protected virtual void Update()
+    void Start()
     {
-        /*
-        // If the object is now seen in the camera, it has been invisible before (when it was spawning)
-        if (GetComponent<Renderer>().isVisible && hasBeenInvisible == false)
-        {
-            Debug.Log("Object spawning in the screen!");
-            hasBeenInvisible = true;
-        }
-        else if (hasBeenInvisible == true) // If has been invisble already and is out of the screen, disable the gameobject
-        {
-            Debug.Log("Object off the screen!");
-            gameObject.SetActive(false);
-            hasBeenInvisible = false;
-        }*/
+        currentHealth = health;
     }
 
     protected virtual void OnDisable()
@@ -49,15 +34,14 @@ public class Entity : MonoBehaviour
 
     protected virtual void OnBecameInvisible()
     {
-        Debug.Log("Entity invisible: " + gameObject.name);
         OnReset();
         ResetEntity();
     }
 
     protected void ResetEntity()
     {
-        gameObject.SetActive(false);
         currentHealth = health;
+        gameObject.SetActive(false);
     }
 
     protected void AddScore()


### PR DESCRIPTION
The aim down enemies usually die in two hits, but after they respawn they would immediately die. This is a small bug because we're using the max health to handle damage calculations instead of an entity's current health.