### PR TITLE
Update spawn rates to use integer instead of floats

### DIFF
--- a/Assets/Scripts/Data/Globals.cs
+++ b/Assets/Scripts/Data/Globals.cs
@@ -59,7 +59,7 @@ public static class Globals
 
     public struct EntityProperties
     {
-        public float spawnRate;
+        public int spawnRate;
         public int maxSpawnCount;
         public Direction spawnDirection;
 
@@ -73,7 +73,7 @@ public static class Globals
         // Allies
         {(EntityType.Ally), new EntityProperties
                                         {
-                                            spawnRate = 0.20f,
+                                            spawnRate = 20,
                                             maxSpawnCount = 3,
                                             spawnDirection = Direction.Up,
                                             possibleSpawnPoints = new List<SpawnPoints>(){SpawnPoints.Start, SpawnPoints.Middle, SpawnPoints.Random},
@@ -82,7 +82,7 @@ public static class Globals
         // Aiming Enemies
         {(EntityType.AimDownEnemy), new EntityProperties
                                         {
-                                            spawnRate = 0.10f,
+                                            spawnRate = 11,
                                             maxSpawnCount = 5,
                                             spawnDirection = Direction.Up,
                                             possibleSpawnPoints = new List<SpawnPoints>(){SpawnPoints.Start, SpawnPoints.Middle, SpawnPoints.Random},
@@ -90,7 +90,7 @@ public static class Globals
                                         }},
         {(EntityType.AimLeftEnemy), new EntityProperties
                                         {
-                                            spawnRate = 0.10f,
+                                            spawnRate = 11,
                                             maxSpawnCount = 5,
                                             spawnDirection = Direction.Right,
                                             possibleSpawnPoints = new List<SpawnPoints>(){SpawnPoints.Start, SpawnPoints.Middle, SpawnPoints.Random},
@@ -98,7 +98,7 @@ public static class Globals
                                         }},
         {(EntityType.AimRightEnemy), new EntityProperties
                                         {
-                                            spawnRate = 0.10f,
+                                            spawnRate = 11,
                                             maxSpawnCount = 5,
                                             spawnDirection = Direction.Left,
                                             possibleSpawnPoints = new List<SpawnPoints>(){SpawnPoints.Start, SpawnPoints.Middle, SpawnPoints.Random},
@@ -107,7 +107,7 @@ public static class Globals
         // Burst Enemies
         {(EntityType.BurstDownEnemy), new EntityProperties
                                         {
-                                            spawnRate = 0.10f,
+                                            spawnRate = 11,
                                             maxSpawnCount = 3,
                                             spawnDirection = Direction.Up,
                                             possibleSpawnPoints = new List<SpawnPoints>(){SpawnPoints.Start, SpawnPoints.Middle, SpawnPoints.Random},
@@ -116,7 +116,7 @@ public static class Globals
         // Curve Enemies
         {(EntityType.CurveLeftEnemy), new EntityProperties
                                         {
-                                            spawnRate = 0.10f,
+                                            spawnRate = 11,
                                             maxSpawnCount = 5,
                                             spawnDirection = Direction.Right,
                                             possibleSpawnPoints = new List<SpawnPoints>(){SpawnPoints.Start, SpawnPoints.Middle},
@@ -124,7 +124,7 @@ public static class Globals
                                         }},
         {(EntityType.CurveRightEnemy), new EntityProperties
                                         {
-                                            spawnRate = 0.10f,
+                                            spawnRate = 11,
                                             spawnDirection = Direction.Left,
                                             maxSpawnCount = 5,
                                             possibleSpawnPoints = new List<SpawnPoints>(){SpawnPoints.Start, SpawnPoints.Middle},
@@ -133,7 +133,7 @@ public static class Globals
         // Spread Enemies
         {(EntityType.SpreadDownEnemy), new EntityProperties
                                         {
-                                            spawnRate = 0.10f,
+                                            spawnRate = 11,
                                             spawnDirection = Direction.Up,
                                             maxSpawnCount = 5,
                                             possibleSpawnPoints = new List<SpawnPoints>(){SpawnPoints.Start, SpawnPoints.Middle, SpawnPoints.Random},
@@ -142,7 +142,7 @@ public static class Globals
         // Straight Down Enemies
         {(EntityType.StraightDownEnemy), new EntityProperties
                                         {
-                                            spawnRate = 0.10f,
+                                            spawnRate = 11,
                                             spawnDirection = Direction.Up,
                                             maxSpawnCount = 5,
                                             possibleSpawnPoints = new List<SpawnPoints>(){SpawnPoints.Start, SpawnPoints.Middle, SpawnPoints.Random},

--- a/Assets/Scripts/Data/Globals.cs
+++ b/Assets/Scripts/Data/Globals.cs
@@ -82,7 +82,7 @@ public static class Globals
         // Aiming Enemies
         {(EntityType.AimDownEnemy), new EntityProperties
                                         {
-                                            spawnRate = 11,
+                                            spawnRate = 10,
                                             maxSpawnCount = 5,
                                             spawnDirection = Direction.Up,
                                             possibleSpawnPoints = new List<SpawnPoints>(){SpawnPoints.Start, SpawnPoints.Middle, SpawnPoints.Random},
@@ -90,7 +90,7 @@ public static class Globals
                                         }},
         {(EntityType.AimLeftEnemy), new EntityProperties
                                         {
-                                            spawnRate = 11,
+                                            spawnRate = 10,
                                             maxSpawnCount = 5,
                                             spawnDirection = Direction.Right,
                                             possibleSpawnPoints = new List<SpawnPoints>(){SpawnPoints.Start, SpawnPoints.Middle, SpawnPoints.Random},
@@ -98,7 +98,7 @@ public static class Globals
                                         }},
         {(EntityType.AimRightEnemy), new EntityProperties
                                         {
-                                            spawnRate = 11,
+                                            spawnRate = 10,
                                             maxSpawnCount = 5,
                                             spawnDirection = Direction.Left,
                                             possibleSpawnPoints = new List<SpawnPoints>(){SpawnPoints.Start, SpawnPoints.Middle, SpawnPoints.Random},
@@ -107,7 +107,7 @@ public static class Globals
         // Burst Enemies
         {(EntityType.BurstDownEnemy), new EntityProperties
                                         {
-                                            spawnRate = 11,
+                                            spawnRate = 10,
                                             maxSpawnCount = 3,
                                             spawnDirection = Direction.Up,
                                             possibleSpawnPoints = new List<SpawnPoints>(){SpawnPoints.Start, SpawnPoints.Middle, SpawnPoints.Random},
@@ -116,7 +116,7 @@ public static class Globals
         // Curve Enemies
         {(EntityType.CurveLeftEnemy), new EntityProperties
                                         {
-                                            spawnRate = 11,
+                                            spawnRate = 10,
                                             maxSpawnCount = 5,
                                             spawnDirection = Direction.Right,
                                             possibleSpawnPoints = new List<SpawnPoints>(){SpawnPoints.Start, SpawnPoints.Middle},
@@ -124,7 +124,7 @@ public static class Globals
                                         }},
         {(EntityType.CurveRightEnemy), new EntityProperties
                                         {
-                                            spawnRate = 11,
+                                            spawnRate = 10,
                                             spawnDirection = Direction.Left,
                                             maxSpawnCount = 5,
                                             possibleSpawnPoints = new List<SpawnPoints>(){SpawnPoints.Start, SpawnPoints.Middle},
@@ -133,7 +133,7 @@ public static class Globals
         // Spread Enemies
         {(EntityType.SpreadDownEnemy), new EntityProperties
                                         {
-                                            spawnRate = 11,
+                                            spawnRate = 10,
                                             spawnDirection = Direction.Up,
                                             maxSpawnCount = 5,
                                             possibleSpawnPoints = new List<SpawnPoints>(){SpawnPoints.Start, SpawnPoints.Middle, SpawnPoints.Random},
@@ -142,7 +142,7 @@ public static class Globals
         // Straight Down Enemies
         {(EntityType.StraightDownEnemy), new EntityProperties
                                         {
-                                            spawnRate = 11,
+                                            spawnRate = 10,
                                             spawnDirection = Direction.Up,
                                             maxSpawnCount = 5,
                                             possibleSpawnPoints = new List<SpawnPoints>(){SpawnPoints.Start, SpawnPoints.Middle, SpawnPoints.Random},

--- a/Assets/Scripts/Level/LevelRunner.cs
+++ b/Assets/Scripts/Level/LevelRunner.cs
@@ -116,8 +116,9 @@ public class LevelRunner : MonoBehaviour
             }
 
             // Spawn next
-            float randomProb = Random.Range(0f, 1f);
-            float cumulativeProb = 0.0f;
+            int randomProb = Random.Range(0, 101);
+            Debug.Log(string.Format("Probability: {0}!", randomProb));
+            int cumulativeProb = 0;
             Globals.EntityType entityType = Globals.EntityType.Ally;
             foreach (Globals.EntityType type in System.Enum.GetValues(typeof(Globals.EntityType)))
             {
@@ -125,7 +126,7 @@ public class LevelRunner : MonoBehaviour
                 if (randomProb <= cumulativeProb)
                 {
                     entityType = type;
-                    Debug.Log(string.Format("Spawning {0}!", entityType));
+                    Debug.Log(string.Format("Spawning enitity: {0}!", entityType));
                     break;
                 }
             }
@@ -139,7 +140,6 @@ public class LevelRunner : MonoBehaviour
             Debug.Log(string.Format("Spawn delay per entity: {0}!", spawnDelay));
             Spawner spawner = SetSpawner(spawnerDirection);
             ObjectPooler pooler = entityObjectPoolers[entityType];
-            Debug.Log(string.Format("Spawning {0} entity!", entityType));
             AdjustDifficulty();
             // Spawn entity
             StartCoroutine(SpawnEntity(pooler, spawner, spawnPoint, spawnStyle, count, spawnDelay));

--- a/Assets/Scripts/Level/LevelRunner.cs
+++ b/Assets/Scripts/Level/LevelRunner.cs
@@ -116,7 +116,7 @@ public class LevelRunner : MonoBehaviour
             }
 
             // Spawn next
-            int randomProb = Random.Range(0, 101);
+            int randomProb = Random.Range(0, 101); // Random.Range for ints takes an exclusive upper bound
             Debug.Log(string.Format("Probability: {0}!", randomProb));
             int cumulativeProb = 0;
             Globals.EntityType entityType = Globals.EntityType.Ally;


### PR DESCRIPTION
Random.Range using floats has a high precision (it goes by 5-6 decimal places), so the probability spawning is not uniform.