### PR TITLE
Update animal skin save data type to string

### DIFF
--- a/Assets/Resources/AnimalData/Default.meta
+++ b/Assets/Resources/AnimalData/Default.meta
@@ -1,6 +1,7 @@
 fileFormatVersion: 2
-guid: 12068d1fc9854bf4c85bcce9b1435150
-PrefabImporter:
+guid: 0c52aaa563b47f048af72a9edb17d54e
+folderAsset: yes
+DefaultImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/Assets/Resources/AnimalData/Default/cat.asset
+++ b/Assets/Resources/AnimalData/Default/cat.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4d4839c79b3d15443af9df463b84ff2e, type: 3}
+  m_Name: cat
+  m_EditorClassIdentifier: 
+  animalName: Cat
+  sprite: {fileID: 21300000, guid: 7b089cf4586ee1542820c0d9ed9a2ace, type: 3}
+  rarity: 0

--- a/Assets/Resources/AnimalData/Default/cat.asset.meta
+++ b/Assets/Resources/AnimalData/Default/cat.asset.meta
@@ -1,7 +1,8 @@
 fileFormatVersion: 2
-guid: 12068d1fc9854bf4c85bcce9b1435150
-PrefabImporter:
+guid: 1f89f4ff687cc0a4db5db70ba32ec770
+NativeFormatImporter:
   externalObjects: {}
+  mainObjectFileID: 11400000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/Resources/AnimalData/Default/kangaroo.asset
+++ b/Assets/Resources/AnimalData/Default/kangaroo.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4d4839c79b3d15443af9df463b84ff2e, type: 3}
+  m_Name: kangaroo
+  m_EditorClassIdentifier: 
+  animalName: Kangaroo
+  sprite: {fileID: 21300000, guid: 3b0c0e34e66eab6438a831992940841e, type: 3}
+  rarity: 0

--- a/Assets/Resources/AnimalData/Default/kangaroo.asset.meta
+++ b/Assets/Resources/AnimalData/Default/kangaroo.asset.meta
@@ -1,7 +1,8 @@
 fileFormatVersion: 2
-guid: 12068d1fc9854bf4c85bcce9b1435150
-PrefabImporter:
+guid: 58864f2c271a2ee42a8fde17b4099a37
+NativeFormatImporter:
   externalObjects: {}
+  mainObjectFileID: 11400000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/Resources/AnimalData/Default/llama.asset
+++ b/Assets/Resources/AnimalData/Default/llama.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4d4839c79b3d15443af9df463b84ff2e, type: 3}
+  m_Name: llama
+  m_EditorClassIdentifier: 
+  animalName: Llama
+  sprite: {fileID: 21300000, guid: be004e9ac5d17724b8a8935f1ea94033, type: 3}
+  rarity: 0

--- a/Assets/Resources/AnimalData/Default/llama.asset.meta
+++ b/Assets/Resources/AnimalData/Default/llama.asset.meta
@@ -1,7 +1,8 @@
 fileFormatVersion: 2
-guid: 12068d1fc9854bf4c85bcce9b1435150
-PrefabImporter:
+guid: dd4b2798ff962bf43afeb7eb842b68a6
+NativeFormatImporter:
   externalObjects: {}
+  mainObjectFileID: 11400000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/Resources/AnimalData/Default/turtle.asset
+++ b/Assets/Resources/AnimalData/Default/turtle.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4d4839c79b3d15443af9df463b84ff2e, type: 3}
+  m_Name: turtle
+  m_EditorClassIdentifier: 
+  animalName: Turtle
+  sprite: {fileID: 21300000, guid: 23114afc0554465408bfa611da6e70ba, type: 3}
+  rarity: 0

--- a/Assets/Resources/AnimalData/Default/turtle.asset.meta
+++ b/Assets/Resources/AnimalData/Default/turtle.asset.meta
@@ -1,7 +1,8 @@
 fileFormatVersion: 2
-guid: 12068d1fc9854bf4c85bcce9b1435150
-PrefabImporter:
+guid: 93e8fa6de49a2d145b80db2e4ed463ce
+NativeFormatImporter:
   externalObjects: {}
+  mainObjectFileID: 11400000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/Resources/AnimalData/Default/unicorn.asset
+++ b/Assets/Resources/AnimalData/Default/unicorn.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4d4839c79b3d15443af9df463b84ff2e, type: 3}
+  m_Name: unicorn
+  m_EditorClassIdentifier: 
+  animalName: Unicorn
+  sprite: {fileID: 21300000, guid: ae0b4250e5b3ca542a50f4c7b04c29f1, type: 3}
+  rarity: 0

--- a/Assets/Resources/AnimalData/Default/unicorn.asset.meta
+++ b/Assets/Resources/AnimalData/Default/unicorn.asset.meta
@@ -1,7 +1,8 @@
 fileFormatVersion: 2
-guid: 12068d1fc9854bf4c85bcce9b1435150
-PrefabImporter:
+guid: 35273a5cfda1c354fa931bd4e8d19444
+NativeFormatImporter:
   externalObjects: {}
+  mainObjectFileID: 11400000
   userData: 
   assetBundleName: 
   assetBundleVariant: 

--- a/Assets/Resources/Prefabs/Allies/TutorialAlly.prefab
+++ b/Assets/Resources/Prefabs/Allies/TutorialAlly.prefab
@@ -26,12 +26,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 948906679947641065}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.8899999, y: 0.8899999, z: 0.8899999}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.000038146973, y: 0, z: 0}
+  m_LocalScale: {x: 183.77, y: 183.77, z: 183.77}
   m_ConstrainProportionsScale: 1
   m_Children: []
-  m_Father: {fileID: 948906680092964855}
+  m_Father: {fileID: 766016096083457116}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &948906679947641620
@@ -105,11 +105,12 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 948906680092964855}
+  - component: {fileID: 8488177235718185248}
+  - component: {fileID: 675320969657246306}
   - component: {fileID: 948906680092964854}
   - component: {fileID: 948906680092964809}
   - component: {fileID: 948906680092964852}
-  - component: {fileID: 948906680092964853}
+  - component: {fileID: 2058838522785027881}
   m_Layer: 7
   m_Name: TutorialAlly
   m_TagString: Ally
@@ -117,22 +118,57 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &948906680092964855
-Transform:
+--- !u!224 &8488177235718185248
+RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 948906680092964808}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -1.522, y: 1.511, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 1
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.75, y: 0.75, z: 0.75}
+  m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 948906679947641621}
+  - {fileID: 766016096083457116}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 150, y: 150}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &675320969657246306
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 948906680092964808}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: be004e9ac5d17724b8a8935f1ea94033, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
 --- !u!212 &948906680092964854
 SpriteRenderer:
   m_ObjectHideFlags: 0
@@ -174,7 +210,7 @@ SpriteRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 0
-  m_Sprite: {fileID: 21300000, guid: fa605d057d197a641bd9467a9bc6e0d1, type: 3}
+  m_Sprite: {fileID: 0}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -182,7 +218,7 @@ SpriteRenderer:
   m_Size: {x: 1, y: 1}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
+  m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
 --- !u!61 &948906680092964809
@@ -198,18 +234,18 @@ BoxCollider2D:
   m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0.01038295, y: 0.029072404}
+  m_Offset: {x: 0.008178711, y: 0.0011444092}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1.3653333, y: 1.3653333}
+    oldSize: {x: 0.64444447, y: 0.5277778}
     newSize: {x: 1, y: 1}
     adaptiveTilingThreshold: 0.5
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 0.66923416, y: 0.50185513}
+  m_Size: {x: 150.01758, y: 149.99954}
   m_EdgeRadius: 0
 --- !u!114 &948906680092964852
 MonoBehaviour:
@@ -226,7 +262,7 @@ MonoBehaviour:
   health: 0
   speed: 1.5
   scoreValue: 150
-  spriteRenderer: {fileID: 0}
+  image: {fileID: 8652355943759243113}
   maxTime: 2
   rescueSpeed: 5
   shield: {fileID: 2100000, guid: 9f7ab3c1699d92a499b057cba8767abb, type: 2}
@@ -234,19 +270,88 @@ MonoBehaviour:
   moveDuration: 3
   stopDuration: 0
   TheShield: {fileID: 948906679947641065}
---- !u!58 &948906680092964853
-CircleCollider2D:
+--- !u!222 &2058838522785027881
+CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 948906680092964808}
-  m_Enabled: 0
-  m_Density: 1
+  m_CullTransparentMesh: 1
+--- !u!1 &3102736052398746284
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 766016096083457116}
+  - component: {fileID: 7026775504293153409}
+  - component: {fileID: 8652355943759243113}
+  m_Layer: 7
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &766016096083457116
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3102736052398746284}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 948906679947641621}
+  m_Father: {fileID: 8488177235718185248}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0.0000076293945, y: 0}
+  m_SizeDelta: {x: 0.000021756, y: 0.00000089407}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7026775504293153409
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3102736052398746284}
+  m_CullTransparentMesh: 1
+--- !u!114 &8652355943759243113
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3102736052398746284}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 0.74
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: 4682bb32994949848baddddea16ef458, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 1
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1

--- a/Assets/Scenes/LevelTutorial.unity
+++ b/Assets/Scenes/LevelTutorial.unity
@@ -304,7 +304,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   tutorialEnemy: {fileID: 997427163}
-  tutorialAlly: {fileID: 1932725978}
+  tutorialAlly: {fileID: 1160185395}
   nukeEnemies: {fileID: 251151636}
   tutorialText: {fileID: 763561191}
 --- !u!1 &97883869
@@ -15864,6 +15864,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   TutorialDone: 0
+  SkipRollAnimations: 0
   currentAnimalSkins: []
   HighScore: 0
 --- !u!1 &472064600
@@ -17011,7 +17012,6 @@ Transform:
   m_Children:
   - {fileID: 251151637}
   - {fileID: 997427164}
-  - {fileID: 1249966145}
   m_Father: {fileID: 0}
   m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -17246,6 +17246,7 @@ MonoBehaviour:
   maxSpawnDelay: 2
   entitiesUntilDifficultyScaling: 5
   commandDelayReduction: 0.15
+  Canvas: {fileID: 0}
   TopSpawner: {fileID: 1300198092}
   BottomSpawner: {fileID: 1450338061}
   LeftSpawner: {fileID: 260806706}
@@ -17298,6 +17299,16 @@ Transform:
   m_Father: {fileID: 423472012}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1160185395 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 948906680092964808, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+  m_PrefabInstance: {fileID: 1292495638}
+  m_PrefabAsset: {fileID: 0}
+--- !u!224 &1160185396 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8488177235718185248, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+  m_PrefabInstance: {fileID: 1292495638}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1164104175
 GameObject:
   m_ObjectHideFlags: 0
@@ -22306,72 +22317,6 @@ ParticleSystem:
         m_PostInfinity: 2
         m_RotationOrder: 4
     vectorLabel1_3: W
---- !u!1001 &1249966144
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    m_TransformParent: {fileID: 1011018424}
-    m_Modifications:
-    - target: {fileID: 948906680092964808, guid: d99680b0e670ab24b93e537a99443966, type: 3}
-      propertyPath: m_Name
-      value: TutorialAlly
-      objectReference: {fileID: 0}
-    - target: {fileID: 948906680092964808, guid: d99680b0e670ab24b93e537a99443966, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 948906680092964855, guid: d99680b0e670ab24b93e537a99443966, type: 3}
-      propertyPath: m_RootOrder
-      value: 2
-      objectReference: {fileID: 0}
-    - target: {fileID: 948906680092964855, guid: d99680b0e670ab24b93e537a99443966, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -2.37
-      objectReference: {fileID: 0}
-    - target: {fileID: 948906680092964855, guid: d99680b0e670ab24b93e537a99443966, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 2.48
-      objectReference: {fileID: 0}
-    - target: {fileID: 948906680092964855, guid: d99680b0e670ab24b93e537a99443966, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 948906680092964855, guid: d99680b0e670ab24b93e537a99443966, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 948906680092964855, guid: d99680b0e670ab24b93e537a99443966, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 948906680092964855, guid: d99680b0e670ab24b93e537a99443966, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 948906680092964855, guid: d99680b0e670ab24b93e537a99443966, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 948906680092964855, guid: d99680b0e670ab24b93e537a99443966, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 948906680092964855, guid: d99680b0e670ab24b93e537a99443966, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 948906680092964855, guid: d99680b0e670ab24b93e537a99443966, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: d99680b0e670ab24b93e537a99443966, type: 3}
---- !u!4 &1249966145 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 948906680092964855, guid: d99680b0e670ab24b93e537a99443966, type: 3}
-  m_PrefabInstance: {fileID: 1249966144}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1270165936
 GameObject:
   m_ObjectHideFlags: 0
@@ -22484,6 +22429,119 @@ Transform:
   m_Father: {fileID: 1450338060}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1292495638
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1298804865}
+    m_Modifications:
+    - target: {fileID: 948906680092964808, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+      propertyPath: m_Name
+      value: TutorialAlly
+      objectReference: {fileID: 0}
+    - target: {fileID: 948906680092964808, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8488177235718185248, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8488177235718185248, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8488177235718185248, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 8488177235718185248, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8488177235718185248, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8488177235718185248, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8488177235718185248, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 8488177235718185248, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 150
+      objectReference: {fileID: 0}
+    - target: {fileID: 8488177235718185248, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 150
+      objectReference: {fileID: 0}
+    - target: {fileID: 8488177235718185248, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 8488177235718185248, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 8488177235718185248, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+      propertyPath: m_LocalScale.z
+      value: 0.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 8488177235718185248, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8488177235718185248, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8488177235718185248, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8488177235718185248, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8488177235718185248, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8488177235718185248, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8488177235718185248, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8488177235718185248, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: -0.5355074
+      objectReference: {fileID: 0}
+    - target: {fileID: 8488177235718185248, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 722.93744
+      objectReference: {fileID: 0}
+    - target: {fileID: 8488177235718185248, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8488177235718185248, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8488177235718185248, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 12068d1fc9854bf4c85bcce9b1435150, type: 3}
 --- !u!1 &1298804864
 GameObject:
   m_ObjectHideFlags: 0
@@ -22518,6 +22576,7 @@ RectTransform:
   - {fileID: 862011991}
   - {fileID: 1270165937}
   - {fileID: 1510789702}
+  - {fileID: 1160185396}
   m_Father: {fileID: 68305558}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -33918,11 +33977,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1930090885}
   m_CullTransparentMesh: 1
---- !u!1 &1932725978 stripped
-GameObject:
-  m_CorrespondingSourceObject: {fileID: 948906680092964808, guid: d99680b0e670ab24b93e537a99443966, type: 3}
-  m_PrefabInstance: {fileID: 1249966144}
-  m_PrefabAsset: {fileID: 0}
 --- !u!4 &2001256330 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 502711955769907586, guid: 5d81b4139569c2a439055cf93c71620c, type: 3}

--- a/Assets/Scripts/Basic/ResourceManager.cs
+++ b/Assets/Scripts/Basic/ResourceManager.cs
@@ -18,7 +18,7 @@ public class ResourceManager : Singleton<ResourceManager>
     public Dictionary<string, AudioClip> SfxDictionary { get; set; }
     public Dictionary<string, AudioClip> RescueSfxDictionary { get; set; }
     public Dictionary<string, TutorialText> TutorialTextDictionary { get; set; }
-    public Dictionary<string, AnimalData[]> AnimalDataDictionary { get; set; }
+    public Dictionary<string, AnimalData[]> RarityToAnimalDataDictionary { get; set; }
     public Dictionary<string, AnimalData> AnimalToDataDictionary { get; set; }
     public Dictionary<string, List<Sprite>> SpaceObjectsDictionary { get; set; }
 
@@ -26,7 +26,7 @@ public class ResourceManager : Singleton<ResourceManager>
 
     public List<string> RescueSfxNames { get; set; }
 
-    public Sprite[] AnimalSpriteArray { get; set; }
+    public AnimalData[] DefaultAnimalArray { get; set; }
 
 
 
@@ -122,12 +122,12 @@ public class ResourceManager : Singleton<ResourceManager>
 
     void LoadAnimalSprites()
     {
-        AnimalSpriteArray = Resources.LoadAll<Sprite>("AnimalSprites/Default");
+        DefaultAnimalArray = Resources.LoadAll<AnimalData>("AnimalData/Default");
     }
 
     void LoadAnimalData()
     {
-        AnimalDataDictionary = new Dictionary<string, AnimalData[]>();
+        RarityToAnimalDataDictionary = new Dictionary<string, AnimalData[]>();
         AnimalToDataDictionary = new Dictionary<string, AnimalData>();
 
         foreach (Globals.GachaponRarities rarity in System.Enum.GetValues(typeof(Globals.GachaponRarities)))
@@ -137,7 +137,7 @@ public class ResourceManager : Singleton<ResourceManager>
             {
                 AnimalToDataDictionary[data.animalName] = data;
             }
-            AnimalDataDictionary[rarity.ToString()] = dataArray;
+            RarityToAnimalDataDictionary[rarity.ToString()] = dataArray;
         }
     }
 

--- a/Assets/Scripts/Data/PlayerData.cs
+++ b/Assets/Scripts/Data/PlayerData.cs
@@ -10,7 +10,8 @@ public class PlayerData : Singleton<PlayerData>
 
     // Dictionary of animals acquired by rolling in gachapon
     public Dictionary<AnimalData, int> acquiredAnimals = new Dictionary<AnimalData, int>();
-    public List<Sprite> currentAnimalSkins = new List<Sprite>();
+    // List of strings deonting the current animals used for the game
+    public List<string> currentAnimalSkins = new List<string>();
     public int Rolls { get; set; }
     private int scoreUntilRoll = 0;
     public int HighScore = 0;
@@ -60,9 +61,9 @@ public class PlayerData : Singleton<PlayerData>
         // Get saved values
         if (!JSONSaver.Instance.LoadData())
         {
-            foreach (Sprite animal in ResourceManager.Instance.AnimalSpriteArray)
+            foreach (AnimalData animal in ResourceManager.Instance.DefaultAnimalArray)
             {
-                currentAnimalSkins.Add(animal);
+                currentAnimalSkins.Add(animal.animalName);
             }
         }
         Debug.Log(currentAnimalSkins.Count);

--- a/Assets/Scripts/Data/SaveData.cs
+++ b/Assets/Scripts/Data/SaveData.cs
@@ -14,7 +14,7 @@ public class SaveData
     public int Rolls;
     public List<SaveAnimalData> AnimalData;
 
-    public List<Sprite> AnimalSkins;
+    public List<string> AnimalSkins;
 
     public SaveData(PlayerData data, List<SaveAnimalData> acquiredAnimalData)
     {

--- a/Assets/Scripts/Entities/Ally.cs
+++ b/Assets/Scripts/Entities/Ally.cs
@@ -58,7 +58,9 @@ public class Ally : Entity
 
     void OnEnable()
     {
-        image.sprite = PlayerData.Instance.currentAnimalSkins[Random.Range(0, PlayerData.Instance.currentAnimalSkins.Count)];
+        string animalName = PlayerData.Instance.currentAnimalSkins[Random.Range(0, PlayerData.Instance.currentAnimalSkins.Count)];
+        AnimalData data = ResourceManager.Instance.AnimalToDataDictionary[animalName];
+        image.sprite = data.sprite;
         Initialize();
     }
 

--- a/Assets/Scripts/Gachapon/AnimalCollection.cs
+++ b/Assets/Scripts/Gachapon/AnimalCollection.cs
@@ -50,7 +50,7 @@ public class AnimalCollection : MonoBehaviour
         {
             // Need to define a local variable since i dynamically changes for listeners
             int slotIndex = i;
-            Sprite sprite = PlayerData.Instance.currentAnimalSkins[i];
+            Sprite sprite = ResourceManager.Instance.AnimalToDataDictionary[PlayerData.Instance.currentAnimalSkins[i]].sprite;
             GameObject slot = (GameObject)Instantiate(Resources.Load("Prefabs/Gachapon/Slot"));
             slot.transform.SetParent(SelectedGrid.transform, false);
             GameObject cardGameObject = slot.transform.Find("Card").gameObject;
@@ -86,7 +86,6 @@ public class AnimalCollection : MonoBehaviour
             slot.GetComponent<Button>().onClick.AddListener(delegate
             {
                 // Set sprite to be visible if it was previously invisible
-                Debug.Log(CurrentAnimalImage.color.a);
                 if (CurrentAnimalImage.color.a == 0)
                 {
                     CurrentAnimalImage.color = new Color32(255, 255, 255, 255);
@@ -101,7 +100,7 @@ public class AnimalCollection : MonoBehaviour
 
     public void SetSelectedAnimal()
     {
-        PlayerData.Instance.currentAnimalSkins[selectionIndex] = CurrentAnimalImage.sprite;
+        PlayerData.Instance.currentAnimalSkins[selectionIndex] = CurrentAnimalText.text;
         selectionSlots[selectionIndex].transform.Find("Animal").GetComponent<Image>().sprite = CurrentAnimalImage.sprite;
         JSONSaver.Instance.SaveData();
     }

--- a/Assets/Scripts/Gachapon/Gachapon.cs
+++ b/Assets/Scripts/Gachapon/Gachapon.cs
@@ -44,10 +44,10 @@ public class Gachapon : MonoBehaviour
 
     public void Roll()
     {
-        if (PlayerData.Instance.Rolls >= 0 && !rolling)
+        if (PlayerData.Instance.Rolls > 0 && !rolling)
         {
             Globals.GachaponRarities rarity = DetermineRarity();
-            AnimalData[] dataArray = ResourceManager.Instance.AnimalDataDictionary[rarity.ToString()];
+            AnimalData[] dataArray = ResourceManager.Instance.RarityToAnimalDataDictionary[rarity.ToString()];
             AnimalData animal = dataArray[Random.Range(0, dataArray.Length)];
             StartCoroutine(GachaAnimation(rarity, animal));
 


### PR DESCRIPTION
- Change save data for animal skins to use strings
- Sort of fix tutorial ally not popping up
- Small gachapon fix & refactor

Using sprites as a save data type caused some problems since sprites saved in JSON format used an ID for referencing. Sometimes the ID isn't parsed properly, causing some issues with loading collection data for animals.

The solution here is to swap the types with strings instead, and pull the animals from the dictionary. All references to using the sprite are replaced with grabbing the actual animal data first.