### PR TITLE
Changing to stay instead of enter

### DIFF
--- a/Assets/Scripts/Entities/Ally.cs
+++ b/Assets/Scripts/Entities/Ally.cs
@@ -157,7 +157,8 @@ public class Ally : Entity
             }
         }
     }
-    void OnTriggerEnter2D(Collider2D collision)
+
+    void OnTriggerStay2D(Collider2D collision)
     {
         if (collision.gameObject.tag == "Player" && rescued)
         {


### PR DESCRIPTION
There is a bug where if you try to save an ally while on top the ally, the ally does not disappear and sticks with the player. This is because when Player and ally are colliding, the trigger enter check is not satisfied (because the ally is not rescued yet). The trigger enter only happens one. So then the player saves the ally, but since the player is already collided with the ally and the check already happened, the if condition doesnt get triggered and the ally doesnt disappear.

Changed it to trigger stay